### PR TITLE
fix: file start/select failure

### DIFF
--- a/octoprint_bambu_connector/connector.py
+++ b/octoprint_bambu_connector/connector.py
@@ -513,15 +513,15 @@ class ConnectedBambuPrinter(
     def start_print(
         self, pos=None, user=None, tags=None, params: dict = None, *args, **kwargs
     ):
-        if not self.active_job.storage == FileDestinations.PRINTER:
+        if not self.current_job.storage == FileDestinations.PRINTER:
             return
 
-        path = os.path.join("/", self.active_job.path)
+        path = os.path.join("/", self.current_job.path)
 
         if params is None:
             params = {}
 
-        job_params = self.active_job.params
+        job_params = self.current_job.params
         if job_params is None:
             job_params = {}
 
@@ -885,6 +885,7 @@ class ConnectedBambuPrinter(
         if self.current_job and (
             self.current_job.path == current_path
             or self.current_job.storage != FileDestinations.PRINTER
+            or printer.active_job_info.stage_name not in PRINTING_STATES
         ):
             return
 


### PR DESCRIPTION
active_job only returns current_job if printing or pausing so was returning None and causing error, resolves #5