### PR TITLE
fix: relocate bpm cache folder to plugin data folder

### DIFF
--- a/octoprint_bambu_connector/__init__.py
+++ b/octoprint_bambu_connector/__init__.py
@@ -46,6 +46,9 @@ class BambuConnectorPlugin(
         ConnectedBambuPrinter._file_manager = self._file_manager
         ConnectedBambuPrinter._plugin_manager = self._plugin_manager
         ConnectedBambuPrinter._plugin_settings = self._settings
+        ConnectedBambuPrinter._bpm_cache_folder = os.path.join(
+            self.get_plugin_data_folder(), "bpm_cache"
+        )
         ConnectedBambuPrinter._thumbs_cache_folder = os.path.join(
             self.get_plugin_data_folder(), "thumbs"
         )

--- a/octoprint_bambu_connector/connector.py
+++ b/octoprint_bambu_connector/connector.py
@@ -4,6 +4,7 @@ import io
 import logging
 import math
 import os
+import pathlib
 import re
 import tempfile
 import threading
@@ -213,6 +214,7 @@ class ConnectedBambuPrinter(
     _file_manager: "FileManager" = None
     _plugin_manager: "PluginManager" = None
     _plugin_settings: "PluginSettings" = None
+    _bpm_cache_folder: str = None
     _thumbs_cache_folder: str = None
     # /injected
 
@@ -377,10 +379,13 @@ class ConnectedBambuPrinter(
         try:
             self._logger.info("Connecting to Bambu")
 
+            bpm_cache_path = pathlib.Path(self._bpm_cache_folder)
+
             config = bpm.bambuconfig.BambuConfig(
                 hostname=self._host,
                 access_code=self._access_code,
                 serial_number=self._serial,
+                bpm_cache_path=bpm_cache_path,
             )
             printer = bpm.bambuprinter.BambuPrinter(config=config)
 


### PR DESCRIPTION
We don't want it polluting the current user's home (`~/.bpm`)