### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ include = [
 bambu_connector = "octoprint_bambu_connector"
 
 [project.urls]
-Homepage = "https://github.com/jneilliii/OctoPrint-BambuConnector"
+Homepage = "https://github.com/OctoPrint/OctoPrint-BambuConnector"
 
 [project.optional-dependencies]
 develop = [


### PR DESCRIPTION
A small update to the project metadata, correcting the homepage URL in the `pyproject.toml` file to point to the new GitHub repository location.